### PR TITLE
v1.6.0

### DIFF
--- a/.github/workflows/nodejs-beta.yml
+++ b/.github/workflows/nodejs-beta.yml
@@ -25,7 +25,7 @@ jobs:
           CI: true
 
   publish-npm:
-    if: github.repository == 'homebridge-plugins/homebridge-honeywell-home'
+    if: github.repository == 'homebridge-plugins/homebridge-platform-wemo'
 
     needs: build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,59 +2,54 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
-## 1.5.6 (2020-05-13)
+## [Version 1.6.0](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.6...1.6.0) (2020-08-14)
 
-## [Version 1.5.6](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.5...1.5.6)
+#### Changes
+
+- Dimmer Night mode: Poll Brightness when turning the lights on. Thanks, [@leeliu](https://github.com/leeliu)!
+
+    - This allows night mode to function with homebridge knowing correct night mode brightness value when lights turn on. (Previously if dimmer was set to 80% normal and 20% night mode, at night when turning on dimmers, Home app would report 80% brightness when in fact the dimmer is 20% brightness. This fixes and now correctly shows 20% brightness.)
+
+## [Version 1.5.6](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.5...1.5.6) (2020-05-13)
+
 
 #### Changes
 
 - small repo updates, no new features or bug fixes.
 
-## 1.5.5 (2020-04-11)
-
-## [Version 1.5.5](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.4...1.5.5)
+## [Version 1.5.5](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.4...1.5.5) (2020-04-11)
 
 #### Features
 
 - update engine dependencies
 
-## 1.5.4 (2020-04-11)
-
-## [Version 1.5.4](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.3...1.5.4)
+## [Version 1.5.4](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.3...1.5.4) (2020-04-11)
 
 #### Features
 
 - remove devDependencies for homebridge-config-ui-x and homebridge.
 - update node engine dependencies
 
-## 1.5.3 (2020-04-08)
-
-## [Version 1.5.3](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.2...1.5.3)
+## [Version 1.5.3](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.2...1.5.3) (2020-04-08)
 
 #### Features
 
 - Update devDependencies for homebridge-config-ui-x and homebridge.
 
-## 1.5.2 (2020-04-08)
-
-## [Version 1.5.2](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.1...1.5.2)
+## [Version 1.5.2](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.1...1.5.2) (2020-04-08)
 
 #### Features
 
 - Spelling Correction
 
-## 1.5.1 (2020-04-07)
-
-## [Version 1.5.1](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.5.0...1.5.1)
+## [Version 1.5.1](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.0...1.5.1) (2020-04-07)
 
 #### Features
 
 - Add support for "discoveryInterval" into config.schema.json
 - Homebridge Verified
 
-## 1.5.0 (2020-04-06)
-
-## [Version 1.5.0](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.4.1...1.5.0)
+## [Version 1.5.0](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.4.1...1.5.0) (2020-04-06)
 
 #### Features
 
@@ -62,16 +57,14 @@ All notable changes to this project will be documented in this file. This projec
 - Add Changelog.
 - Repo Updates.
 
-## [Version 1.4.1](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.4.0...1.4.1)
+## [Version 1.4.1](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.4.0...1.4.1) (2020-04-06)
 
 #### Features
 
 - Fix miss spelling
 - Fix config.schema.json
 
-## 1.4.0 (2020-04-05)
-
-## [Version 1.4.0](https://github.com/donavanbecker/homebridge-honeywell-home/compare/v1.3.8...1.4.0)
+## [Version 1.4.0](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.3.8...1.4.0) (2020-04-05)
 
 #### Changes
 

--- a/index.js
+++ b/index.js
@@ -824,6 +824,17 @@ WemoAccessory.prototype.setSwitchState = function(state, callback) {
             if(!err) {
                 this.log("%s - Set state: %s", this.accessory.displayName, (value ? "On" : "Off"));
                 callback(null);
+
+                // for dimmer, poll brightness for ON events (supports night mode)
+                if (value && this.device.deviceType === Wemo.DEVICE_TYPE.Dimmer) {
+                    this.client.getBrightness(function(err, brightness) {
+                        if (err) {
+                            this.log("%s - Error ON brightness", this.accessory.displayName);
+                            return;
+                        }
+                        this.updateBrightness(brightness);
+                    }.bind(this));
+                }
             }
             else {
                 this.log("%s - Set state FAILED: %s. Error: %s", this.accessory.displayName, (value ? "on" : "off"), err.code);
@@ -1146,6 +1157,17 @@ WemoAccessory.prototype.updateSwitchState = function(state) {
     if (switchState.value !== value) {
         this.log("%s - Get state: %s", this.accessory.displayName, (value ? "On" : "Off"));
         switchState.updateValue(value);
+
+        // for dimmer, poll brightness for ON events (supports night mode)
+        if (value && this.device.deviceType === Wemo.DEVICE_TYPE.Dimmer) {
+            this.client.getBrightness(function(err, brightness) {
+                if (err) {
+                    this.log("%s - Error ON brightness", this.accessory.displayName);
+                    return;
+                }
+                this.updateBrightness(brightness);
+            }.bind(this));
+        }
 
         if(value === false && this.device.deviceType === Wemo.DEVICE_TYPE.Insight) {
             this.updateOutletInUse(0);

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "url": "https://github.com/homebridge-plugins/homebridge-platform-wemo/issues"
     },
     "engines": {
-        "node": ">=8.15.1",
-        "homebridge": ">=0.4.29"
+        "node": "^12.0.0",
+        "homebridge": "^1.1.2"
     },
     "files": [
         "README.md",
@@ -38,10 +38,10 @@
         "index.js"
     ],
     "dependencies": {
-        "wemo-client": ">=0.15.0",
-        "debug": "*"
+        "wemo-client": "^0.15.0",
+        "debug": "^4.1.1"
     },
     "devDependencies": {
-        "nodemon": ">=2.0.2"
+        "nodemon": "^2.0.2"
     }
 }


### PR DESCRIPTION
## [Version 1.6.0](https://github.com/homebridge-plugins/homebridge-platform-wemo/compare/v1.5.6...1.6.0) (2020-08-14)

#### Changes

- Dimmer Night mode: Poll Brightness when turning the lights on. Thanks, [@leeliu](https://github.com/leeliu)!

    - This allows night mode to function with homebridge knowing correct night mode brightness value when lights turn on. (Previously if dimmer was set to 80% normal and 20% night mode, at night when turning on dimmers, Home app would report 80% brightness when in fact the dimmer is 20% brightness. This fixes and now correctly shows 20% brightness.)
