### PR TITLE
v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "homebridge-platform-wemo",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "homebridge-platform-wemo",
     "displayName": "Homebridge Wemo",
-    "version": "1.5.6",
+    "version": "1.6.0",
     "author": "homebridge-plugins",
     "description": "A Wemo https://www.wemo.com plugin for Homebridge: https://github.com/homebridge/homebridge",
     "main": "index.js",


### PR DESCRIPTION
#### Changes

- Dimmer Night mode: Poll Brightness when turning the lights on. Thanks, [@leeliu](https://github.com/leeliu)!

    - This allows night mode to function with homebridge knowing correct night mode brightness value when lights turn on. (Previously if dimmer was set to 80% normal and 20% night mode, at night when turning on dimmers, Home app would report 80% brightness when in fact the dimmer is 20% brightness. This fixes and now correctly shows 20% brightness.)
